### PR TITLE
Switch to SSE HTTP transport with Jetty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <slf4j.version>2.0.16</slf4j.version>
         <logback.version>1.5.13</logback.version>
         <caffeine.version>3.1.8</caffeine.version>
+        <jetty.version>11.0.20</jetty.version>
         <junit.jupiter.version>5.10.0</junit.jupiter.version>
         <mockito.version>5.10.0</mockito.version>
         <wiremock.version>2.35.1</wiremock.version>
@@ -134,8 +135,20 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
-        </dependency>        
-        
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>

--- a/src/main/java/com/serpstat/SerpstatMcpServer.java
+++ b/src/main/java/com/serpstat/SerpstatMcpServer.java
@@ -5,13 +5,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.serpstat.domains.utils.VersionUtils;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpSyncServer;
-import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
+import io.modelcontextprotocol.server.transport.HttpServletSseServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities;
 
 import com.serpstat.core.ToolRegistry;
 import com.serpstat.core.SerpstatApiClient;
 
+import java.net.InetSocketAddress;
 import java.util.Arrays;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
 
 /**
  * Main class for the MCP server for Serpstat API.
@@ -19,8 +24,16 @@ import java.util.Arrays;
  */
 public class SerpstatMcpServer {
 
+    private static final String HOST_ENV = "SERPSTAT_MCP_HOST";
+    private static final String PORT_ENV = "SERPSTAT_MCP_PORT";
+    private static final String DEFAULT_HOST = "0.0.0.0";
+    private static final int DEFAULT_PORT = 8080;
+    private static final String MESSAGE_ENDPOINT = "/messages";
+    private static final String EVENTS_ENDPOINT = "/events";
+
     private final String apiToken;
     private McpSyncServer mcpServer;
+    private Server server;
 
     public SerpstatMcpServer(String apiToken) {
         this.apiToken = apiToken;
@@ -55,47 +68,111 @@ public class SerpstatMcpServer {
     }
 
     public void start() throws Exception {
-            // Create API client
-            SerpstatApiClient apiClient = new SerpstatApiClient(apiToken);
+        String host = resolveHost();
+        int port = resolvePort();
+        String baseUrl = String.format("http://%s:%d", host, port);
 
-            // Create a tool registry and automatically register all tools
-            ToolRegistry toolRegistry = new ToolRegistry(apiClient);
+        var transportProvider = HttpServletSseServerTransportProvider.builder()
+                .objectMapper(new ObjectMapper())
+                .baseUrl(baseUrl)
+                .messageEndpoint(MESSAGE_ENDPOINT)
+                .sseEndpoint(EVENTS_ENDPOINT)
+                .build();
 
-            // Create STDIO transport
-            var transportProvider = new StdioServerTransportProvider(new ObjectMapper());
+        this.server = new Server(new InetSocketAddress(host, port));
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
+        context.setContextPath("/");
+        context.addServlet(new ServletHolder(transportProvider), "/*");
+        this.server.setHandler(context);
 
-            // Create and configure an MCP server
-            this.mcpServer = McpServer.sync(transportProvider)
-                    .serverInfo("serpstat-mcp-server", VersionUtils.getVersion())
-                    .capabilities(ServerCapabilities.builder()
-                            .tools(true)
-                            .logging()
-                            .build())
-                    .build();
+        this.server.start();
 
-            // Automatically register all tools
-            toolRegistry.registerAllTools(mcpServer);
+        // Create API client
+        SerpstatApiClient apiClient = new SerpstatApiClient(apiToken);
 
-            System.err.println("🚀 Serpstat MCP Server started successfully!");
-            System.err.printf("📊 Registered %d tools across %d domains%n",
-                    toolRegistry.getToolCount(), toolRegistry.getDomainCount());
-            System.err.println("⏳ Waiting for MCP client connections...");
+        // Create a tool registry and automatically register all tools
+        ToolRegistry toolRegistry = new ToolRegistry(apiClient);
 
-            // Graceful shutdown
-            Runtime.getRuntime().addShutdownHook(new Thread(this::shutdown));
+        // Create and configure an MCP server
+        this.mcpServer = McpServer.sync(transportProvider)
+                .serverInfo("serpstat-mcp-server", VersionUtils.getVersion())
+                .capabilities(ServerCapabilities.builder()
+                        .tools(true)
+                        .logging()
+                        .build())
+                .build();
 
-            // Block the main thread
-            Thread.currentThread().join();
-        }
+        // Automatically register all tools
+        toolRegistry.registerAllTools(mcpServer);
+
+        System.err.println("🚀 Serpstat MCP Server started successfully!");
+        System.err.printf("📊 Registered %d tools across %d domains%n",
+                toolRegistry.getToolCount(), toolRegistry.getDomainCount());
+        System.err.printf("⚙️  Configuration -> host: %s (env %s), port: %d (env %s)%n", host, HOST_ENV, port, PORT_ENV);
+        System.err.printf("🌐 SSE transport available at %s%s with message endpoint %s%s%n",
+                baseUrl, EVENTS_ENDPOINT, baseUrl, MESSAGE_ENDPOINT);
+        System.err.println("⏳ Waiting for MCP client connections over SSE...");
+
+        // Graceful shutdown
+        Runtime.getRuntime().addShutdownHook(new Thread(this::shutdown));
+
+        // Block the main thread until Jetty is stopped
+        server.join();
+    }
 
     private void shutdown() {
         System.err.println("🛑 Shutting down Serpstat MCP Server...");
+
+        if (server != null) {
+            try {
+                server.stop();
+                System.err.println("✅ Jetty server stopped.");
+            } catch (Exception e) {
+                System.err.println("❌ Error while stopping Jetty server: " + e.getMessage());
+            } finally {
+                try {
+                    server.destroy();
+                    System.err.println("🧹 Jetty server resources released.");
+                } catch (Exception e) {
+                    System.err.println("❌ Error while destroying Jetty server: " + e.getMessage());
+                }
+            }
+        }
+
         try {
             if (mcpServer != null) {
                 mcpServer.closeGracefully();
+                System.err.println("✅ MCP server closed gracefully.");
             }
         } catch (Exception e) {
-            System.err.println("❌ Error during shutdown: " + e.getMessage());
+            System.err.println("❌ Error during MCP shutdown: " + e.getMessage());
+        }
+    }
+
+    private String resolveHost() {
+        String envHost = System.getenv(HOST_ENV);
+        if (envHost == null || envHost.isBlank()) {
+            return DEFAULT_HOST;
+        }
+        return envHost.trim();
+    }
+
+    private int resolvePort() {
+        String envPort = System.getenv(PORT_ENV);
+        if (envPort == null || envPort.isBlank()) {
+            return DEFAULT_PORT;
+        }
+        try {
+            int parsedPort = Integer.parseInt(envPort.trim());
+            if (parsedPort <= 0 || parsedPort > 65535) {
+                System.err.printf("⚠️  Port '%s' from %s is out of range. Falling back to default %d.%n",
+                        envPort, PORT_ENV, DEFAULT_PORT);
+                return DEFAULT_PORT;
+            }
+            return parsedPort;
+        } catch (NumberFormatException e) {
+            System.err.printf("⚠️  Invalid port '%s' in %s. Falling back to default %d.%n", envPort, PORT_ENV, DEFAULT_PORT);
+            return DEFAULT_PORT;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add Jetty server and servlet dependencies so the MCP server can expose an SSE servlet
- replace the STDIO transport with HttpServletSseServerTransportProvider and wire it into a Jetty Server with configurable host/port
- improve startup/shutdown logging and ensure Jetty is started, joined, and torn down alongside the MCP server

## Testing
- `mvn -DskipTests package` *(fails: unable to download Maven dependencies because network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d02f4a69d48326a94f7fc88ac66ef8