### PR TITLE
Switch SSE endpoint to /sse and support HEAD health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,27 @@ This is alpha release v0.0.2.
    
 6. **Check console and open given url in browser**
 
-   ```bash 
+   ```bash
    user@pc:~/repo/serpstat-mcp-server-java$ ./inspect.sh
    Starting MCP inspector...
    ⚙️ Proxy server listening on port 6277
    🔍 MCP Inspector is up and running at http://127.0.0.1:6274 🚀
    ```
-   
+
+## Configuration
+
+### Environment variables
+
+- `SERPSTAT_API_TOKEN` – **required**. Authentication token for Serpstat API requests.
+- `SERPSTAT_MCP_HOST` – optional. Overrides the Jetty bind host (default `0.0.0.0`).
+- `SERPSTAT_MCP_PORT` – optional. Overrides the Jetty bind port (default `8080`).
+- `SERPSTAT_MCP_BASE_URL` – optional. Overrides the URL announced to MCP clients for the `/messages` endpoint. Set it to `relative` to emit only `/messages?...` so reverse proxies can rewrite the absolute URL, or provide a full base like `https://example.com` (trailing slash is trimmed).
+
+### HTTP endpoints
+
+- `GET /sse` – Server-Sent Events stream used by MCP clients. Also accepts `HEAD` so you can probe the endpoint for health checks behind a load balancer or uptime monitor without initiating a long-lived stream.
+- `POST /messages` – JSON-RPC endpoint used for bidirectional MCP messaging.
+
 ## Integration into Claude Desktop for Linux
 
 - Click the menu icon (three lines, "burger") in the top right corner of Claude Desktop to open **Settings**.

--- a/src/main/java/com/serpstat/SerpstatMcpServer.java
+++ b/src/main/java/com/serpstat/SerpstatMcpServer.java
@@ -11,10 +11,23 @@ import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities;
 import com.serpstat.core.ToolRegistry;
 import com.serpstat.core.SerpstatApiClient;
 
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
+import java.util.EnumSet;
 
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 
@@ -26,10 +39,12 @@ public class SerpstatMcpServer {
 
     private static final String HOST_ENV = "SERPSTAT_MCP_HOST";
     private static final String PORT_ENV = "SERPSTAT_MCP_PORT";
+    private static final String BASE_URL_ENV = "SERPSTAT_MCP_BASE_URL";
     private static final String DEFAULT_HOST = "0.0.0.0";
     private static final int DEFAULT_PORT = 8080;
     private static final String MESSAGE_ENDPOINT = "/messages";
-    private static final String EVENTS_ENDPOINT = "/events";
+    private static final String EVENTS_ENDPOINT = "/sse";
+    private static final String RELATIVE_BASE_URL_VALUE = "relative";
 
     private final String apiToken;
     private McpSyncServer mcpServer;
@@ -70,7 +85,8 @@ public class SerpstatMcpServer {
     public void start() throws Exception {
         String host = resolveHost();
         int port = resolvePort();
-        String baseUrl = String.format("http://%s:%d", host, port);
+        String defaultBaseUrl = String.format("http://%s:%d", host, port);
+        String baseUrl = resolveBaseUrl(defaultBaseUrl);
 
         var transportProvider = HttpServletSseServerTransportProvider.builder()
                 .objectMapper(new ObjectMapper())
@@ -82,6 +98,9 @@ public class SerpstatMcpServer {
         this.server = new Server(new InetSocketAddress(host, port));
         ServletContextHandler context = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
         context.setContextPath("/");
+        context.addFilter(new FilterHolder(new HeadSsePingFilter(EVENTS_ENDPOINT)),
+                EVENTS_ENDPOINT,
+                EnumSet.of(DispatcherType.REQUEST));
         context.addServlet(new ServletHolder(transportProvider), "/*");
         this.server.setHandler(context);
 
@@ -109,8 +128,11 @@ public class SerpstatMcpServer {
         System.err.printf("📊 Registered %d tools across %d domains%n",
                 toolRegistry.getToolCount(), toolRegistry.getDomainCount());
         System.err.printf("⚙️  Configuration -> host: %s (env %s), port: %d (env %s)%n", host, HOST_ENV, port, PORT_ENV);
-        System.err.printf("🌐 SSE transport available at %s%s with message endpoint %s%s%n",
-                baseUrl, EVENTS_ENDPOINT, baseUrl, MESSAGE_ENDPOINT);
+        System.err.printf("🌐 SSE transport available at %s%s%n", defaultBaseUrl, EVENTS_ENDPOINT);
+        String advertisedMessageEndpoint = baseUrl.isEmpty()
+                ? MESSAGE_ENDPOINT
+                : baseUrl + MESSAGE_ENDPOINT;
+        System.err.printf("📨 Message endpoint advertised as %s%n", advertisedMessageEndpoint);
         System.err.println("⏳ Waiting for MCP client connections over SSE...");
 
         // Graceful shutdown
@@ -173,6 +195,83 @@ public class SerpstatMcpServer {
         } catch (NumberFormatException e) {
             System.err.printf("⚠️  Invalid port '%s' in %s. Falling back to default %d.%n", envPort, PORT_ENV, DEFAULT_PORT);
             return DEFAULT_PORT;
+        }
+    }
+
+    private String resolveBaseUrl(String defaultBaseUrl) {
+        String envBaseUrl = System.getenv(BASE_URL_ENV);
+        if (envBaseUrl == null || envBaseUrl.isBlank()) {
+            return defaultBaseUrl;
+        }
+
+        String trimmed = envBaseUrl.trim();
+        if (trimmed.isEmpty()) {
+            System.err.printf("⚠️  %s is set but empty. Falling back to default %s.%n", BASE_URL_ENV, defaultBaseUrl);
+            return defaultBaseUrl;
+        }
+
+        if (RELATIVE_BASE_URL_VALUE.equalsIgnoreCase(trimmed)) {
+            System.err.printf("🔁 %s=relative → advertising message endpoint as relative path.%n", BASE_URL_ENV);
+            return "";
+        }
+
+        if (trimmed.endsWith("/")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1);
+        }
+
+        System.err.printf("🌐 Using custom base URL from %s: %s%n", BASE_URL_ENV, trimmed);
+        return trimmed;
+    }
+
+    private static final class HeadSsePingFilter implements Filter {
+        private final String sseEndpoint;
+
+        private HeadSsePingFilter(String sseEndpoint) {
+            this.sseEndpoint = sseEndpoint;
+        }
+
+        @Override
+        public void init(FilterConfig filterConfig) throws ServletException {
+            // No initialization required.
+        }
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+                throws IOException, ServletException {
+            if (request instanceof HttpServletRequest httpRequest
+                    && response instanceof HttpServletResponse httpResponse
+                    && "HEAD".equalsIgnoreCase(httpRequest.getMethod())
+                    && matchesEndpoint(httpRequest)) {
+                httpResponse.setStatus(HttpServletResponse.SC_OK);
+                httpResponse.setContentType("text/event-stream");
+                httpResponse.setHeader("Cache-Control", "no-cache");
+                httpResponse.setContentLength(0);
+                return;
+            }
+
+            chain.doFilter(request, response);
+        }
+
+        @Override
+        public void destroy() {
+            // No cleanup required.
+        }
+
+        private boolean matchesEndpoint(HttpServletRequest request) {
+            String requestUri = request.getRequestURI();
+            if (requestUri == null) {
+                return false;
+            }
+
+            if (requestUri.equals(sseEndpoint)) {
+                return true;
+            }
+
+            if (!sseEndpoint.endsWith("/") && requestUri.equals(sseEndpoint + "/")) {
+                return true;
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose the SSE transport on `/sse` so reverse proxies can publish the expected route
- serve `HEAD /sse` with a 200 text/event-stream response to support load-balancer or uptime probes
- document the public HTTP endpoints and their semantics in the README

## Testing
- `mvn -q -DskipTests package` *(fails: unable to reach repo.maven.apache.org in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d03409d57883269bb7ef337801b801